### PR TITLE
Remove components requiring dangerous permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,3 +22,13 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.1.1'
 }
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:2.3.3"
+    }
+}

--- a/app/src/main/java/catchpower/gogo/mediavolumeonly/AccessibilityService.java
+++ b/app/src/main/java/catchpower/gogo/mediavolumeonly/AccessibilityService.java
@@ -38,25 +38,4 @@ public class AccessibilityService extends android.accessibilityservice.Accessibi
 
     @Override
     public void onInterrupt() { }
-
-    @Override
-    protected boolean onKeyEvent(KeyEvent event) {
-        if (event != null) {
-            if(event.getAction() == KeyEvent.ACTION_UP || event.getAction() == KeyEvent.ACTION_DOWN) {
-                if (event.getKeyCode() == KeyEvent.KEYCODE_VOLUME_DOWN || event.getKeyCode() == KeyEvent.KEYCODE_VOLUME_UP) {
-                    SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
-                    if( pref.getBoolean("volume_key_lock", false) == true){
-                        Utils.setMusicKey(this);
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                Utils.setMusicKey(AccessibilityService.this);
-                            }
-                        }, 100);
-                    }
-                }
-            }
-        }
-        return super.onKeyEvent(event);
-    }
 }

--- a/app/src/main/res/xml/accessibilityservice.xml
+++ b/app/src/main/res/xml/accessibilityservice.xml
@@ -2,8 +2,8 @@
 <accessibility-service
     android:accessibilityEventTypes="typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagIncludeNotImportantViews|flagRequestFilterKeyEvents"
-    android:canRequestFilterKeyEvents="true"
+    android:accessibilityFlags="flagIncludeNotImportantViews"
+    android:canRequestFilterKeyEvents="false"
     android:description="@string/accessibility_description"
     android:settingsActivity="catchpower.gogo.mediavolumeonly.SettingsActivity"
     xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Remove component of AccessibilityService.java that waits on the key command. Since there's already the onAccessibilityEvent method, I don't think the key method is needed, and that way the app doesn't have the (alarming!) permission of "observe text you type".